### PR TITLE
docs: rewrite README to match actual implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,612 @@
+# Solana Account Abstraction (AA)
+
+A comprehensive account abstraction implementation for Solana that enables smart accounts with multiple authentication methods, flexible permissions, and delegation capabilities.
+
+## 🎯 Vision & Concept
+
+This project aims to bring EIP-4337-style account abstraction to Solana, allowing users to:
+
+- **Use any authentication method**: Ethereum wallets, WebAuthn/passkeys, OIDC providers, or custom schemes
+- **Manage accounts flexibly**: Add/remove authentication methods without losing access
+- **Delegate permissions**: Allow other identities to act on your behalf with granular controls
+- **Recover accounts**: Multiple authentication paths prevent lockout scenarios
+- **Interact cross-chain**: Ethereum signatures work natively, enabling cross-chain workflows
+
+## 🏗 Architecture Overview
+
+### Account Model
+
+The system implements an **identity-based account abstraction model** where each abstract account can have multiple authentication identities with granular permissions.
+
+```
+┌─────────────────────────────────────┐
+│           Abstract Account          │
+├─────────────────────────────────────┤
+│ • Account ID (unique)               │
+│ • Nonce (replay protection)         │
+│ • Multiple Identities:              │
+│   ├─ Ethereum Wallet               │
+│   ├─ WebAuthn Authenticator        │
+│   ├─ OIDC Provider                 │
+│   └─ Custom Authentication         │
+│ • Permission Matrix                │
+│ • Recovery Mechanisms              │
+└─────────────────────────────────────┘
+```
+
+### Identity Types
+
+#### 1. Ethereum Wallet Identity
+
+Uses secp256k1 signatures compatible with Ethereum tooling:
+
+```rust
+Identity::Wallet(WalletType::Ethereum(address))
+```
+
+#### 2. WebAuthn Identity
+
+Browser-based authentication using FIDO2/WebAuthn:
+
+```rust
+Identity::WebAuthn(WebAuthnAuthenticator {
+    credential_id,
+    public_key,
+    authenticator_data
+})
+```
+
+#### 3. OIDC Identity (Future)
+
+OAuth-based authentication with RSA signatures:
+
+```rust
+Identity::OIDC(OIDCProvider {
+    issuer,
+    subject,
+    public_key
+})
+```
+
+### Permission System (Ideal)
+
+Each identity can have fine-grained permissions:
+
+```rust
+pub struct IdentityPermissions {
+    // Basic permissions
+    can_transact: bool,           // Execute standard transactions
+    can_add_identity: bool,       // Add new identities to account
+    can_remove_identity: bool,    // Remove identities from account
+    can_modify_permissions: bool, // Change permission levels
+    can_delete_account: bool,     // Delete the entire account
+
+    // Delegation permissions
+    enable_act_as: bool,          // Can act on behalf of other identities
+    act_as_targets: Vec<Identity>, // Specific identities this can act as
+
+    // Advanced permissions
+    spending_limits: Option<SpendingLimits>, // Transaction value limits
+    time_restrictions: Option<TimeWindow>,   // Time-based access control
+    action_whitelist: Option<Vec<Action>>,   // Allowed action types
+
+    // Recovery permissions
+    is_recovery_identity: bool,   // Can initiate account recovery
+    recovery_delay: Option<u64>,  // Time delay for recovery actions
+}
+```
+
+### Transaction Authorization Flow (Ideal)
+
+```mermaid
+graph TD
+    A[User Initiates Transaction] --> B[Select Authentication Method]
+    B --> C[Generate Signature]
+    C --> D[Submit UserOp]
+    D --> E[Verify Signature]
+    E --> F[Check Identity Membership]
+    F --> G[Validate Permissions]
+    G --> H[Check Act-As Delegation]
+    H --> I[Verify Transaction Limits]
+    I --> J[Execute Transaction]
+    J --> K[Update Account State]
+```
+
+## 🔐 Authentication Methods
+
+### Ethereum Signature Authentication
+
+**Status**: ✅ Implemented  
+**Use Cases**: Cross-chain compatibility, existing Ethereum wallet integration
+
+```typescript
+// Sign transaction with Ethereum wallet
+const signature = await wallet.signMessage(transactionData);
+const userOp = {
+  auth: { ethereum: { signature, address } },
+  transaction: { account_id, nonce, action },
+};
+```
+
+### WebAuthn Authentication
+
+**Status**: 🚧 Partial (verification only)  
+**Use Cases**: Passwordless authentication, mobile biometrics, hardware keys
+
+```typescript
+// Authenticate with WebAuthn
+const credential = await navigator.credentials.create({
+  publicKey: { challenge, ... }
+});
+const userOp = {
+  auth: { webauthn: { credential, signature } },
+  transaction: { account_id, nonce, action }
+};
+```
+
+### OIDC Authentication
+
+**Status**: 🔬 Experimental  
+**Use Cases**: Social login, enterprise SSO, OAuth providers
+
+```typescript
+// Authenticate with OIDC provider
+const jwt = await oidcProvider.getToken();
+const userOp = {
+  auth: { oidc: { jwt, signature } },
+  transaction: { account_id, nonce, action },
+};
+```
+
+## 🎭 Delegation & Act-As System (Ideal)
+
+The system supports sophisticated delegation mechanisms:
+
+### Simple Delegation
+
+```rust
+// Identity A acts as Identity B
+UserOp {
+  auth: Auth::Ethereum(identity_a_signature),
+  act_as: Some(identity_b),
+  transaction: Transaction { ... }
+}
+```
+
+### Multi-Signature Scenarios
+
+```rust
+// Require multiple identities for high-value transactions
+UserOp {
+  auth: Auth::MultiSig(vec![
+    identity_a_signature,
+    identity_b_signature
+  ]),
+  transaction: Transaction { ... }
+}
+```
+
+### Time-Limited Delegation
+
+```rust
+// Temporary delegation with expiration
+IdentityPermissions {
+  enable_act_as: true,
+  act_as_targets: vec![identity_b],
+  time_restrictions: Some(TimeWindow {
+    start: now(),
+    end: now() + 24_hours
+  })
+}
+```
+
+## 🔒 Security Model
+
+### Layered Security Approach
+
+1. **Cryptographic Verification**: All operations require valid signatures
+2. **Identity-Based Access Control**: Fine-grained permissions per identity
+3. **Delegation Validation**: Strict verification of act-as relationships
+4. **Replay Protection**: Nonce-based transaction ordering
+5. **Rate Limiting**: Spending limits and time-based restrictions
+6. **Recovery Mechanisms**: Multiple paths to regain account access
+
+### Account Recovery (Ideal)
+
+```rust
+// Recovery scenario: Lost primary device
+pub struct RecoveryProcess {
+  recovery_identities: Vec<Identity>,    // Backup authentication methods
+  recovery_threshold: u8,                // Required signatures for recovery
+  recovery_delay: Duration,              // Time delay before recovery
+  social_recovery: Option<SocialRecovery>, // Trusted contacts
+}
+```
+
+### Permission Inheritance (Ideal)
+
+```rust
+// Hierarchical permission model
+pub enum PermissionLevel {
+  Owner,      // Full control, can add/remove other identities
+  Admin,      // Can modify permissions below admin level
+  User,       // Can transact within limits
+  Recovery,   // Can initiate recovery procedures only
+  ReadOnly,   // Can view but not modify
+}
+```
+
+## 🚧 Current Implementation Status
+
+### ✅ Implemented Features
+
+- [x] Abstract account creation and management
+- [x] Ethereum signature verification and execution
+- [x] Basic identity membership validation
+- [x] Nonce-based replay protection
+- [x] PDA-based account addressing
+- [x] Account deletion and cleanup
+- [x] Transaction buffer for large operations
+
+### 🚧 Partially Implemented
+
+- [ ] WebAuthn signature verification (verification only, no execution)
+- [ ] Basic permission structure (defined but not enforced)
+- [ ] RSA/OIDC verification (localnet only)
+
+### ❌ Missing Critical Features
+
+The following features are essential for production deployment:
+
+## 📋 TODOs - Security & Permission System
+
+### Critical Security Implementation (P0)
+
+- [ ] **Permission Validation System**
+
+  ```rust
+  // TODO: Implement permission validation in transaction processing
+  // Location: programs/solana-aa/src/contract/transaction/validation.rs:42-45
+  // Missing: Complete permission checking logic
+  ```
+
+- [ ] **Act-As Delegation Validation**
+
+  ```rust
+  // TODO: Include verification for act_as functionality
+  // Location: programs/solana-aa/src/contract/transaction/validation.rs:43
+  // Missing: Delegation relationship verification
+  ```
+
+- [ ] **Remove Unauthorized Direct Methods**
+
+  ```rust
+  // TODO: Remove or secure direct account methods that bypass authentication
+  // Location: programs/solana-aa/src/lib.rs:139-175
+  // Issue: delete_account, add_identity, remove_identity bypass auth
+  ```
+
+- [ ] **Complete WebAuthn Execution Path**
+  ```rust
+  // TODO: Implement execute_webauthn function
+  // Location: Create new execution path for WebAuthn transactions
+  // Missing: Complete WebAuthn transaction execution
+  ```
+
+### Authentication Implementation (P1)
+
+- [ ] **Multi-Signature Support**
+
+  ```rust
+  // TODO: Implement multi-signature transaction validation
+  // Location: New module needed for multi-sig operations
+  // Missing: Threshold-based authentication
+  ```
+
+- [ ] **RSA/OIDC Production Support**
+
+  ```rust
+  // TODO: Solve compute unit limitations for RSA verification
+  // Location: programs/solana-aa/src/contract/auth/rsa/
+  // Issue: Exceeds Solana compute limits on mainnet
+  ```
+
+- [ ] **Transaction Expiration**
+  ```rust
+  // TODO: Add timestamp-based transaction expiration
+  // Location: programs/solana-aa/src/types/transaction/transaction.rs
+  // Missing: Time-based transaction validity
+  ```
+
+### Permission System Implementation (P1)
+
+- [ ] **Hierarchical Permission Model**
+
+  ```rust
+  // TODO: Implement owner/admin/user role hierarchy
+  // Location: programs/solana-aa/src/types/identity/mod.rs
+  // Missing: Role-based access control
+  ```
+
+- [ ] **Spending Limits**
+
+  ```rust
+  // TODO: Add transaction value and frequency limits
+  // Location: New module for spending controls
+  // Missing: Economic security controls
+  ```
+
+- [ ] **Time-Based Restrictions**
+  ```rust
+  // TODO: Implement time windows and session timeouts
+  // Location: programs/solana-aa/src/types/identity/permissions.rs
+  // Missing: Temporal access controls
+  ```
+
+### Recovery System Implementation (P2)
+
+- [ ] **Social Recovery**
+
+  ```rust
+  // TODO: Implement trusted contact recovery mechanism
+  // Location: New module for recovery operations
+  // Missing: Social recovery system
+  ```
+
+- [ ] **Recovery Time Delays**
+
+  ```rust
+  // TODO: Add configurable delays for recovery operations
+  // Location: Recovery module
+  // Missing: Time-locked recovery procedures
+  ```
+
+- [ ] **Identity Recovery Procedures**
+  ```rust
+  // TODO: Implement lost identity replacement workflows
+  // Location: Recovery module
+  // Missing: Secure identity replacement
+  ```
+
+### Advanced Features (P2)
+
+- [ ] **Batch Transactions**
+
+  ```rust
+  // TODO: Support multiple operations in single transaction
+  // Location: New module for batch operations
+  // Missing: Atomic multi-operation support
+  ```
+
+- [ ] **Session Keys**
+
+  ```rust
+  // TODO: Implement temporary keys for frequent operations
+  // Location: New module for session management
+  // Missing: Temporary delegation system
+  ```
+
+- [ ] **Gas Sponsorship/Paymaster**
+  ```rust
+  // TODO: Add fee delegation and sponsorship capabilities
+  // Location: New module for fee management
+  // Missing: Transaction fee abstraction
+  ```
+
+### Security Hardening (P1)
+
+- [ ] **Input Validation**
+
+  ```rust
+  // TODO: Add comprehensive bounds checking for all inputs
+  // Location: Throughout codebase
+  // Missing: Robust input sanitization
+  ```
+
+- [ ] **Memory Safety**
+
+  ```rust
+  // TODO: Replace all unwrap() calls with proper error handling
+  // Location: Multiple files with panic conditions
+  // Issue: Potential denial of service attacks
+  ```
+
+- [ ] **Resource Limits**
+
+  ```rust
+  // TODO: Implement compute unit budgeting and memory limits
+  // Location: Throughout execution paths
+  // Missing: Resource exhaustion protection
+  ```
+
+- [ ] **Audit Logging**
+  ```rust
+  // TODO: Add comprehensive security event logging
+  // Location: All security-critical operations
+  // Missing: Security monitoring capabilities
+  ```
+
+## 🚀 Getting Started
+
+### Prerequisites
+
+- Rust 1.70+
+- Solana CLI 1.16+
+- Anchor Framework 0.31+
+- Node.js 18+ (for tests)
+
+### Installation
+
+```bash
+# Clone the repository
+git clone https://github.com/your-org/solana-aa
+cd solana-aa
+
+# Install dependencies
+npm install
+
+# Build the program
+anchor build
+
+# Run tests
+anchor test
+```
+
+### Creating an Abstract Account
+
+```typescript
+import { createAbstractAccount } from "./utils/solana";
+
+// Create account with Ethereum wallet
+const ethereumIdentity = {
+  identity: {
+    wallet: { ethereum: walletAddress },
+  },
+  permissions: {
+    enable_act_as: false, // Basic permissions
+  },
+};
+
+const accountId = await createAbstractAccount(ethereumIdentity);
+```
+
+### Adding Additional Identities
+
+```typescript
+// Add WebAuthn for passwordless auth
+const webauthnIdentity = {
+  identity: {
+    webauthn: {
+      credential_id: credentialId,
+      public_key: publicKey,
+    },
+  },
+  permissions: {
+    enable_act_as: true, // Can act as other identities
+    spending_limits: {
+      daily_limit: 1000_000_000, // 1 SOL per day
+    },
+  },
+};
+
+await addIdentity(accountId, webauthnIdentity);
+```
+
+## 🧪 Testing
+
+### Running the Test Suite
+
+```bash
+# Run all tests
+npm test
+
+# Run specific test categories
+npm run test:auth        # Authentication tests
+npm run test:permissions # Permission system tests
+npm run test:recovery    # Recovery mechanism tests
+npm run test:security    # Security vulnerability tests
+```
+
+### Test Coverage
+
+Current test coverage focuses on:
+
+- ✅ Ethereum signature authentication
+- ✅ Basic account operations
+- ✅ Nonce management
+- ⚠️ Limited permission testing (incomplete implementation)
+- ❌ Missing comprehensive security tests
+
+## 🔍 Security Considerations
+
+### Current Security Status
+
+**⚠️ WARNING: This implementation is NOT production-ready**
+
+Critical security issues that must be resolved:
+
+1. **Missing Permission Validation**: Any identity can perform privileged operations
+2. **Incomplete Authentication**: Only Ethereum signatures are functional
+3. **No Recovery Mechanisms**: No way to recover from compromised or lost identities
+4. **Memory Safety Issues**: Multiple panic conditions in core logic
+5. **Resource Exhaustion**: No protection against expensive operations
+
+### Security Roadmap
+
+See `security.md` for detailed vulnerability analysis and remediation plan.
+
+### Recommended Security Practices
+
+1. **Multi-Factor Setup**: Always configure multiple authentication methods
+2. **Permission Minimization**: Grant least privileges necessary
+3. **Regular Audits**: Monitor account activity and permission changes
+4. **Recovery Planning**: Establish recovery procedures before they're needed
+5. **Spending Limits**: Configure appropriate transaction limits
+
+## 🛣 Roadmap
+
+### Phase 1: Security Foundation (Q3 2024)
+
+- [ ] Complete permission validation system
+- [ ] Implement all authentication methods
+- [ ] Add comprehensive error handling
+- [ ] Security audit and penetration testing
+
+### Phase 2: Advanced Features (Q4 2024)
+
+- [ ] Multi-signature support
+- [ ] Social recovery mechanisms
+- [ ] Session key management
+- [ ] Cross-chain integration
+
+### Phase 3: Ecosystem Integration (Q1 2025)
+
+- [ ] Wallet integration (Phantom, Solflare)
+- [ ] DApp SDK and tooling
+- [ ] Gas sponsorship/paymaster
+- [ ] Advanced delegation patterns
+
+### Phase 4: Enterprise Features (Q2 2025)
+
+- [ ] Enterprise SSO integration
+- [ ] Compliance and auditing tools
+- [ ] Advanced recovery workflows
+- [ ] Custom authentication plugins
+
+## 🤝 Contributing
+
+We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
+
+### Development Priorities
+
+1. **Security First**: All contributions must prioritize security
+2. **Test Coverage**: New features require comprehensive tests
+3. **Documentation**: Code must be well-documented
+4. **Compatibility**: Maintain backwards compatibility where possible
+
+### Reporting Security Issues
+
+Please report security vulnerabilities to security@yourorg.com. Do not create public issues for security problems.
+
+## 📚 Documentation
+
+- [Architecture Overview](docs/architecture.md)
+- [Authentication Guide](docs/authentication.md)
+- [Permission System](docs/permissions.md)
+- [Security Analysis](security.md)
+- [API Reference](docs/api.md)
+
+## 📄 License
+
+This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
+
+## 🙏 Acknowledgments
+
+- Solana Foundation for the excellent development environment
+- EIP-4337 authors for account abstraction inspiration
+- Anchor Framework team for the development tools
+- Security researchers who contributed to the analysis
+
+---
+
+**⚠️ Disclaimer**: This software is experimental and not ready for production use. Use at your own risk and always conduct thorough security audits before deploying to mainnet.

--- a/README.md
+++ b/README.md
@@ -1,612 +1,146 @@
-# Solana Account Abstraction (AA)
+# Solana Account Abstraction
 
-A comprehensive account abstraction implementation for Solana that enables smart accounts with multiple authentication methods, flexible permissions, and delegation capabilities.
+An experimental [Anchor](https://www.anchor-lang.com/) program exploring account abstraction on Solana: smart accounts that are owned by a PDA and controlled by external credentials — Ethereum wallets, WebAuthn passkeys, and (experimentally) OIDC tokens — instead of Solana Ed25519 keypairs.
 
-## 🎯 Vision & Concept
+> **Status: research prototype.** Not audited, several security checks are intentionally incomplete (see [Known gaps](#known-gaps)). Do not use with real funds.
 
-This project aims to bring EIP-4337-style account abstraction to Solana, allowing users to:
+Program ID (localnet): `2PYNfKSoM7rFJeMuvEidASxgpdPAXYascVDmH6jpBa7o`
 
-- **Use any authentication method**: Ethereum wallets, WebAuthn/passkeys, OIDC providers, or custom schemes
-- **Manage accounts flexibly**: Add/remove authentication methods without losing access
-- **Delegate permissions**: Allow other identities to act on your behalf with granular controls
-- **Recover accounts**: Multiple authentication paths prevent lockout scenarios
-- **Interact cross-chain**: Ethereum signatures work natively, enabling cross-chain workflows
+## Design
 
-## 🏗 Architecture Overview
+Solana ties account ownership to a single Ed25519 key. This program decouples the two: each abstract account is a PDA that stores a list of *identities* (authentication methods), and any registered identity can authorize transactions for the account. A Solana keypair is still needed to pay fees, but it carries no authority — authorization comes entirely from the external signature.
 
-### Account Model
+Signature verification is delegated to Solana's native precompiles rather than done in-program:
 
-The system implements an **identity-based account abstraction model** where each abstract account can have multiple authentication identities with granular permissions.
+| Identity | Scheme | Verified by | Status |
+|---|---|---|---|
+| Ethereum wallet | secp256k1 + keccak256 ("ek256") | [secp256k1 precompile](https://docs.anza.xyz/runtime/programs#secp256k1-program) | Verification + execution |
+| WebAuthn passkey | secp256r1 (P-256) + SHA-256 | [secp256r1 precompile](https://docs.anza.xyz/runtime/programs#secp256r1-program) | Verification only |
+| OIDC (Google) | RSA-2048 PKCS#1 v1.5 + SHA-256 (RS256) | `big_mod_exp` syscall / `rsa` crate | PoC, localnet only |
+
+The pattern is the standard precompile + instruction introspection flow: the client places the precompile verification instruction immediately before the program instruction in the same transaction. If the signature is invalid the runtime aborts the whole transaction, so by the time the program runs, the signature is known-good. The program then reads the precompile instruction back through the instructions sysvar to learn *what* was verified (signer + message) and uses that as the authenticated caller identity.
+
+### On-chain state
+
+Two account types, defined in [`programs/solana-aa/src/types`](programs/solana-aa/src/types):
+
+- **`AccountManager`** — singleton PDA, seed `["account_manager"]`. Holds `next_account_id`, a monotonically increasing `u64`. Accounts get sequential IDs; IDs of deleted accounts are never reused. This enables cheap account discovery and prevents recreate-at-same-address attacks.
+- **`AbstractAccount`** — one PDA per account, seeds `["abstract_account", account_id_le_bytes]`. Holds:
+  - `nonce: u128` — incremented on every executed transaction, for replay protection
+  - `identities: Vec<IdentityWithPermissions>` — the authentication methods that control the account
+  - `bump: u8` — cached to skip re-derivation on later calls
+
+The account is reallocated as identities are added and removed; rent for freed space is refunded to the signer ([`utils/pda.rs`](programs/solana-aa/src/utils/pda.rs)).
+
+### Transaction execution (`execute_ek256`)
+
+The only fully wired execution path today is Ethereum-signed transactions ([`contract/transaction/execute.rs`](programs/solana-aa/src/contract/transaction/execute.rs)):
+
+1. The client Borsh-serializes `Transaction { account_id, nonce, action }` and signs `keccak256(bytes)` with an Ethereum key.
+2. The client submits one Solana transaction containing two instructions:
+   ```
+   ix N-1: secp256k1 precompile   (signature, eth_address, message)
+   ix N:   solana_aa::execute_ek256(account_id)
+   ```
+3. The runtime verifies the secp256k1 signature; an invalid signature aborts the transaction.
+4. `execute_ek256` loads instruction `N-1` from the instructions sysvar and validates its shape ([`contract/auth/ek256.rs`](programs/solana-aa/src/contract/auth/ek256.rs)): it must be the secp256k1 program, carry exactly one signature, and all offsets must point into that same instruction (cross-instruction data references are rejected).
+5. The Ethereum address from the precompile data becomes the caller identity, and the signed message is deserialized into a `Transaction`.
+6. Validation ([`contract/transaction/validation.rs`](programs/solana-aa/src/contract/transaction/validation.rs)) checks that the identity is registered on the account, the transaction nonce matches the account nonce, and the signed `account_id` matches the PDA being operated on — then increments the nonce.
+7. The action is dispatched:
+   - `RemoveAccount` — close the PDA and refund rent
+   - `AddIdentity(IdentityWithPermissions)` — register a new authentication method
+   - `RemoveIdentity(Identity)` — remove one
+
+Because the signed message embeds the account ID, the nonce, and the action, a signature cannot be replayed against another account, replayed twice, or repurposed for a different operation.
+
+WebAuthn has the verification half implemented ([`contract/auth/secp256r1_sha256.rs`](programs/solana-aa/src/contract/auth/secp256r1_sha256.rs)) — same introspection pattern against the secp256r1 precompile, where the signed payload is `authenticator_data || sha256(client_data_json)` and the transaction hash travels in the client data challenge — but there is no `execute_*` path for it yet.
+
+### Instructions
+
+| Instruction | Purpose |
+|---|---|
+| `init_contract` / `close_contract` | Create / close the `AccountManager` singleton |
+| `create_account` | Create an `AbstractAccount` with its first identity. Deliberately unauthenticated: anyone can create an account, but only its registered identities can control it |
+| `execute_ek256` | Main entrypoint — verify an Ethereum-signed `Transaction` and dispatch its action |
+| `delete_account` / `add_identity` / `remove_identity` | Direct account mutations that **bypass signature auth** — development helpers only, must be removed or secured before any real deployment |
+| `verify_eth` / `get_eth_data` | Debug helpers for secp256k1 precompile introspection |
+| `verify_webauthn` / `get_webauthn_data` | Same for the secp256r1 precompile |
+| `verify_oidc_rsa_native` / `verify_oidc_rsa_crate` | Experimental RSA verification of OIDC token signatures |
+| `init_storage` / `store_chunk` / `retrieve_chunk` / `get_data_metadata` / `close_storage` | Transaction buffer (below) |
+
+### Transaction buffer
+
+[`contract/transaction_buffer.rs`](programs/solana-aa/src/contract/transaction_buffer.rs) implements chunked storage for payloads that exceed Solana's ~1232-byte transaction size limit (e.g. OIDC JWTs). Data is split into ≤900-byte chunks and written across multiple transactions into a per-payer PDA keyed by `data_id`, with a hash of the full dataset for integrity. Current implementation loads the whole chunk vector on the heap, so it is bounded by Solana's 32 KB heap limit — zero-copy accounts are the planned fix.
+
+### OIDC / RSA verification (PoC)
+
+Two proof-of-concept paths for verifying Google OIDC JWT signatures (RS256) on-chain, both currently dead ends outside localnet ([`contract/auth/rsa`](programs/solana-aa/src/contract/auth/rsa), [`tests/rsa/README.md`](tests/rsa/README.md)):
+
+- **`rsa_native`** — uses the `big_mod_exp` syscall. Works on localnet, but the syscall is not enabled on mainnet/devnet ([solana-labs/solana#32520](https://github.com/solana-labs/solana/pull/32520)).
+- **`rsa_rsa_crate`** — pure-Rust modular exponentiation via the `rsa` crate. Exceeds the compute unit limit.
+- Splitting verification across multiple transactions was also tried and removed — it exceeds the heap limit.
+
+Tracked in [#13](https://github.com/Pessina/solana-aa/issues/13). Google's JWKS public keys are currently hardcoded in [`constants.rs`](programs/solana-aa/src/contract/auth/rsa/constants.rs); a real implementation would need an oracle/governance flow to keep them rotated.
+
+## Known gaps
+
+What the validation layer enforces today: identity membership, nonce equality (then increment), and account-ID binding. What it does not:
+
+- **Permissions are stored but never enforced.** `IdentityPermissions { enable_act_as }` is persisted, and `UserOp.act_as` exists in the types, but `is_transaction_authorized` checks neither.
+- **Unauthenticated mutation instructions.** `delete_account`, `add_identity`, `remove_identity` operate without any signature verification.
+- **No WebAuthn execution path**, and the `WebAuthnAuthenticator` identity does not yet bind `client_data.origin` / `rpIdHash` — a passkey reused across sites could be replayed cross-origin.
+- **No bounds on account growth.** The identity list can grow toward the heap limit without a guard.
+- **Single-signature only.** The precompile introspection rejects multi-signature instructions; there is no multisig or threshold support.
+
+## Repository layout
 
 ```
-┌─────────────────────────────────────┐
-│           Abstract Account          │
-├─────────────────────────────────────┤
-│ • Account ID (unique)               │
-│ • Nonce (replay protection)         │
-│ • Multiple Identities:              │
-│   ├─ Ethereum Wallet               │
-│   ├─ WebAuthn Authenticator        │
-│   ├─ OIDC Provider                 │
-│   └─ Custom Authentication         │
-│ • Permission Matrix                │
-│ • Recovery Mechanisms              │
-└─────────────────────────────────────┘
+programs/solana-aa/src/
+├── lib.rs                       # Instruction entrypoints
+├── pda_seeds.rs                 # PDA seed constants
+├── contract/
+│   ├── accounts.rs              # Abstract account creation
+│   ├── contract_lifecycle.rs    # AccountManager init/close
+│   ├── transaction_buffer.rs    # Chunked storage for large payloads
+│   ├── auth/
+│   │   ├── ek256.rs             # secp256k1 (Ethereum) precompile introspection
+│   │   ├── secp256r1_sha256.rs  # secp256r1 (WebAuthn) precompile introspection
+│   │   └── rsa/                 # OIDC RSA verification PoC (localnet only)
+│   └── transaction/
+│       ├── execute.rs           # execute_ek256: authenticate → validate → dispatch
+│       └── validation.rs        # Identity membership + nonce + account binding
+├── types/
+│   ├── account.rs               # AbstractAccount (nonce, identities, realloc)
+│   ├── account_manager.rs       # Sequential account-ID counter
+│   ├── identity/                # Identity enum: Wallet (Ethereum), WebAuthn
+│   └── transaction/             # Transaction { account_id, nonce, action }
+└── utils/pda.rs                 # PDA realloc/close helpers with rent accounting
+
+borsh/      # TS Borsh schemas mirroring the on-chain types
+utils/      # TS client helpers: precompile instruction builders, signers, PDAs
+tests/      # Integration tests (ts-mocha against a local validator)
 ```
 
-### Identity Types
+## Development
 
-#### 1. Ethereum Wallet Identity
-
-Uses secp256k1 signatures compatible with Ethereum tooling:
-
-```rust
-Identity::Wallet(WalletType::Ethereum(address))
-```
-
-#### 2. WebAuthn Identity
-
-Browser-based authentication using FIDO2/WebAuthn:
-
-```rust
-Identity::WebAuthn(WebAuthnAuthenticator {
-    credential_id,
-    public_key,
-    authenticator_data
-})
-```
-
-#### 3. OIDC Identity (Future)
-
-OAuth-based authentication with RSA signatures:
-
-```rust
-Identity::OIDC(OIDCProvider {
-    issuer,
-    subject,
-    public_key
-})
-```
-
-### Permission System (Ideal)
-
-Each identity can have fine-grained permissions:
-
-```rust
-pub struct IdentityPermissions {
-    // Basic permissions
-    can_transact: bool,           // Execute standard transactions
-    can_add_identity: bool,       // Add new identities to account
-    can_remove_identity: bool,    // Remove identities from account
-    can_modify_permissions: bool, // Change permission levels
-    can_delete_account: bool,     // Delete the entire account
-
-    // Delegation permissions
-    enable_act_as: bool,          // Can act on behalf of other identities
-    act_as_targets: Vec<Identity>, // Specific identities this can act as
-
-    // Advanced permissions
-    spending_limits: Option<SpendingLimits>, // Transaction value limits
-    time_restrictions: Option<TimeWindow>,   // Time-based access control
-    action_whitelist: Option<Vec<Action>>,   // Allowed action types
-
-    // Recovery permissions
-    is_recovery_identity: bool,   // Can initiate account recovery
-    recovery_delay: Option<u64>,  // Time delay for recovery actions
-}
-```
-
-### Transaction Authorization Flow (Ideal)
-
-```mermaid
-graph TD
-    A[User Initiates Transaction] --> B[Select Authentication Method]
-    B --> C[Generate Signature]
-    C --> D[Submit UserOp]
-    D --> E[Verify Signature]
-    E --> F[Check Identity Membership]
-    F --> G[Validate Permissions]
-    G --> H[Check Act-As Delegation]
-    H --> I[Verify Transaction Limits]
-    I --> J[Execute Transaction]
-    J --> K[Update Account State]
-```
-
-## 🔐 Authentication Methods
-
-### Ethereum Signature Authentication
-
-**Status**: ✅ Implemented  
-**Use Cases**: Cross-chain compatibility, existing Ethereum wallet integration
-
-```typescript
-// Sign transaction with Ethereum wallet
-const signature = await wallet.signMessage(transactionData);
-const userOp = {
-  auth: { ethereum: { signature, address } },
-  transaction: { account_id, nonce, action },
-};
-```
-
-### WebAuthn Authentication
-
-**Status**: 🚧 Partial (verification only)  
-**Use Cases**: Passwordless authentication, mobile biometrics, hardware keys
-
-```typescript
-// Authenticate with WebAuthn
-const credential = await navigator.credentials.create({
-  publicKey: { challenge, ... }
-});
-const userOp = {
-  auth: { webauthn: { credential, signature } },
-  transaction: { account_id, nonce, action }
-};
-```
-
-### OIDC Authentication
-
-**Status**: 🔬 Experimental  
-**Use Cases**: Social login, enterprise SSO, OAuth providers
-
-```typescript
-// Authenticate with OIDC provider
-const jwt = await oidcProvider.getToken();
-const userOp = {
-  auth: { oidc: { jwt, signature } },
-  transaction: { account_id, nonce, action },
-};
-```
-
-## 🎭 Delegation & Act-As System (Ideal)
-
-The system supports sophisticated delegation mechanisms:
-
-### Simple Delegation
-
-```rust
-// Identity A acts as Identity B
-UserOp {
-  auth: Auth::Ethereum(identity_a_signature),
-  act_as: Some(identity_b),
-  transaction: Transaction { ... }
-}
-```
-
-### Multi-Signature Scenarios
-
-```rust
-// Require multiple identities for high-value transactions
-UserOp {
-  auth: Auth::MultiSig(vec![
-    identity_a_signature,
-    identity_b_signature
-  ]),
-  transaction: Transaction { ... }
-}
-```
-
-### Time-Limited Delegation
-
-```rust
-// Temporary delegation with expiration
-IdentityPermissions {
-  enable_act_as: true,
-  act_as_targets: vec![identity_b],
-  time_restrictions: Some(TimeWindow {
-    start: now(),
-    end: now() + 24_hours
-  })
-}
-```
-
-## 🔒 Security Model
-
-### Layered Security Approach
-
-1. **Cryptographic Verification**: All operations require valid signatures
-2. **Identity-Based Access Control**: Fine-grained permissions per identity
-3. **Delegation Validation**: Strict verification of act-as relationships
-4. **Replay Protection**: Nonce-based transaction ordering
-5. **Rate Limiting**: Spending limits and time-based restrictions
-6. **Recovery Mechanisms**: Multiple paths to regain account access
-
-### Account Recovery (Ideal)
-
-```rust
-// Recovery scenario: Lost primary device
-pub struct RecoveryProcess {
-  recovery_identities: Vec<Identity>,    // Backup authentication methods
-  recovery_threshold: u8,                // Required signatures for recovery
-  recovery_delay: Duration,              // Time delay before recovery
-  social_recovery: Option<SocialRecovery>, // Trusted contacts
-}
-```
-
-### Permission Inheritance (Ideal)
-
-```rust
-// Hierarchical permission model
-pub enum PermissionLevel {
-  Owner,      // Full control, can add/remove other identities
-  Admin,      // Can modify permissions below admin level
-  User,       // Can transact within limits
-  Recovery,   // Can initiate recovery procedures only
-  ReadOnly,   // Can view but not modify
-}
-```
-
-## 🚧 Current Implementation Status
-
-### ✅ Implemented Features
-
-- [x] Abstract account creation and management
-- [x] Ethereum signature verification and execution
-- [x] Basic identity membership validation
-- [x] Nonce-based replay protection
-- [x] PDA-based account addressing
-- [x] Account deletion and cleanup
-- [x] Transaction buffer for large operations
-
-### 🚧 Partially Implemented
-
-- [ ] WebAuthn signature verification (verification only, no execution)
-- [ ] Basic permission structure (defined but not enforced)
-- [ ] RSA/OIDC verification (localnet only)
-
-### ❌ Missing Critical Features
-
-The following features are essential for production deployment:
-
-## 📋 TODOs - Security & Permission System
-
-### Critical Security Implementation (P0)
-
-- [ ] **Permission Validation System**
-
-  ```rust
-  // TODO: Implement permission validation in transaction processing
-  // Location: programs/solana-aa/src/contract/transaction/validation.rs:42-45
-  // Missing: Complete permission checking logic
-  ```
-
-- [ ] **Act-As Delegation Validation**
-
-  ```rust
-  // TODO: Include verification for act_as functionality
-  // Location: programs/solana-aa/src/contract/transaction/validation.rs:43
-  // Missing: Delegation relationship verification
-  ```
-
-- [ ] **Remove Unauthorized Direct Methods**
-
-  ```rust
-  // TODO: Remove or secure direct account methods that bypass authentication
-  // Location: programs/solana-aa/src/lib.rs:139-175
-  // Issue: delete_account, add_identity, remove_identity bypass auth
-  ```
-
-- [ ] **Complete WebAuthn Execution Path**
-  ```rust
-  // TODO: Implement execute_webauthn function
-  // Location: Create new execution path for WebAuthn transactions
-  // Missing: Complete WebAuthn transaction execution
-  ```
-
-### Authentication Implementation (P1)
-
-- [ ] **Multi-Signature Support**
-
-  ```rust
-  // TODO: Implement multi-signature transaction validation
-  // Location: New module needed for multi-sig operations
-  // Missing: Threshold-based authentication
-  ```
-
-- [ ] **RSA/OIDC Production Support**
-
-  ```rust
-  // TODO: Solve compute unit limitations for RSA verification
-  // Location: programs/solana-aa/src/contract/auth/rsa/
-  // Issue: Exceeds Solana compute limits on mainnet
-  ```
-
-- [ ] **Transaction Expiration**
-  ```rust
-  // TODO: Add timestamp-based transaction expiration
-  // Location: programs/solana-aa/src/types/transaction/transaction.rs
-  // Missing: Time-based transaction validity
-  ```
-
-### Permission System Implementation (P1)
-
-- [ ] **Hierarchical Permission Model**
-
-  ```rust
-  // TODO: Implement owner/admin/user role hierarchy
-  // Location: programs/solana-aa/src/types/identity/mod.rs
-  // Missing: Role-based access control
-  ```
-
-- [ ] **Spending Limits**
-
-  ```rust
-  // TODO: Add transaction value and frequency limits
-  // Location: New module for spending controls
-  // Missing: Economic security controls
-  ```
-
-- [ ] **Time-Based Restrictions**
-  ```rust
-  // TODO: Implement time windows and session timeouts
-  // Location: programs/solana-aa/src/types/identity/permissions.rs
-  // Missing: Temporal access controls
-  ```
-
-### Recovery System Implementation (P2)
-
-- [ ] **Social Recovery**
-
-  ```rust
-  // TODO: Implement trusted contact recovery mechanism
-  // Location: New module for recovery operations
-  // Missing: Social recovery system
-  ```
-
-- [ ] **Recovery Time Delays**
-
-  ```rust
-  // TODO: Add configurable delays for recovery operations
-  // Location: Recovery module
-  // Missing: Time-locked recovery procedures
-  ```
-
-- [ ] **Identity Recovery Procedures**
-  ```rust
-  // TODO: Implement lost identity replacement workflows
-  // Location: Recovery module
-  // Missing: Secure identity replacement
-  ```
-
-### Advanced Features (P2)
-
-- [ ] **Batch Transactions**
-
-  ```rust
-  // TODO: Support multiple operations in single transaction
-  // Location: New module for batch operations
-  // Missing: Atomic multi-operation support
-  ```
-
-- [ ] **Session Keys**
-
-  ```rust
-  // TODO: Implement temporary keys for frequent operations
-  // Location: New module for session management
-  // Missing: Temporary delegation system
-  ```
-
-- [ ] **Gas Sponsorship/Paymaster**
-  ```rust
-  // TODO: Add fee delegation and sponsorship capabilities
-  // Location: New module for fee management
-  // Missing: Transaction fee abstraction
-  ```
-
-### Security Hardening (P1)
-
-- [ ] **Input Validation**
-
-  ```rust
-  // TODO: Add comprehensive bounds checking for all inputs
-  // Location: Throughout codebase
-  // Missing: Robust input sanitization
-  ```
-
-- [ ] **Memory Safety**
-
-  ```rust
-  // TODO: Replace all unwrap() calls with proper error handling
-  // Location: Multiple files with panic conditions
-  // Issue: Potential denial of service attacks
-  ```
-
-- [ ] **Resource Limits**
-
-  ```rust
-  // TODO: Implement compute unit budgeting and memory limits
-  // Location: Throughout execution paths
-  // Missing: Resource exhaustion protection
-  ```
-
-- [ ] **Audit Logging**
-  ```rust
-  // TODO: Add comprehensive security event logging
-  // Location: All security-critical operations
-  // Missing: Security monitoring capabilities
-  ```
-
-## 🚀 Getting Started
-
-### Prerequisites
-
-- Rust 1.70+
-- Solana CLI 1.16+
-- Anchor Framework 0.31+
-- Node.js 18+ (for tests)
-
-### Installation
+Requirements: Rust, [Solana CLI (Agave) 2.x](https://docs.anza.xyz/cli/install), [Anchor CLI 0.31.1](https://www.anchor-lang.com/docs/installation), Node.js with Yarn.
 
 ```bash
-# Clone the repository
-git clone https://github.com/your-org/solana-aa
-cd solana-aa
-
-# Install dependencies
-npm install
-
-# Build the program
+yarn install
 anchor build
-
-# Run tests
-anchor test
+anchor test      # builds, deploys to a local validator, runs all specs
+yarn lint        # prettier check
 ```
 
-### Creating an Abstract Account
+### Test suite
 
-```typescript
-import { createAbstractAccount } from "./utils/solana";
+| Spec | Covers |
+|---|---|
+| [`tests/accounts.spec.ts`](tests/accounts.spec.ts) | Account creation, sequential IDs, identity add/remove, closing |
+| [`tests/execute_ek256.spec.ts`](tests/execute_ek256.spec.ts) | End-to-end signed-transaction execution with Ethereum keys |
+| [`tests/borsh-ek256-auth.spec.ts`](tests/borsh-ek256-auth.spec.ts) | secp256k1 precompile verification and introspection |
+| [`tests/secp256r1-sha256-auth.spec.ts`](tests/secp256r1-sha256-auth.spec.ts) | WebAuthn (P-256) verification, precompile and program error cases |
+| [`tests/transaction-buffer.spec.ts`](tests/transaction-buffer.spec.ts) | Chunked storage lifecycle |
+| [`tests/rsa/*.spec.ts`](tests/rsa) | OIDC RSA verification PoCs (localnet only) |
 
-// Create account with Ethereum wallet
-const ethereumIdentity = {
-  identity: {
-    wallet: { ethereum: walletAddress },
-  },
-  permissions: {
-    enable_act_as: false, // Basic permissions
-  },
-};
-
-const accountId = await createAbstractAccount(ethereumIdentity);
-```
-
-### Adding Additional Identities
-
-```typescript
-// Add WebAuthn for passwordless auth
-const webauthnIdentity = {
-  identity: {
-    webauthn: {
-      credential_id: credentialId,
-      public_key: publicKey,
-    },
-  },
-  permissions: {
-    enable_act_as: true, // Can act as other identities
-    spending_limits: {
-      daily_limit: 1000_000_000, // 1 SOL per day
-    },
-  },
-};
-
-await addIdentity(accountId, webauthnIdentity);
-```
-
-## 🧪 Testing
-
-### Running the Test Suite
-
-```bash
-# Run all tests
-npm test
-
-# Run specific test categories
-npm run test:auth        # Authentication tests
-npm run test:permissions # Permission system tests
-npm run test:recovery    # Recovery mechanism tests
-npm run test:security    # Security vulnerability tests
-```
-
-### Test Coverage
-
-Current test coverage focuses on:
-
-- ✅ Ethereum signature authentication
-- ✅ Basic account operations
-- ✅ Nonce management
-- ⚠️ Limited permission testing (incomplete implementation)
-- ❌ Missing comprehensive security tests
-
-## 🔍 Security Considerations
-
-### Current Security Status
-
-**⚠️ WARNING: This implementation is NOT production-ready**
-
-Critical security issues that must be resolved:
-
-1. **Missing Permission Validation**: Any identity can perform privileged operations
-2. **Incomplete Authentication**: Only Ethereum signatures are functional
-3. **No Recovery Mechanisms**: No way to recover from compromised or lost identities
-4. **Memory Safety Issues**: Multiple panic conditions in core logic
-5. **Resource Exhaustion**: No protection against expensive operations
-
-### Security Roadmap
-
-See `security.md` for detailed vulnerability analysis and remediation plan.
-
-### Recommended Security Practices
-
-1. **Multi-Factor Setup**: Always configure multiple authentication methods
-2. **Permission Minimization**: Grant least privileges necessary
-3. **Regular Audits**: Monitor account activity and permission changes
-4. **Recovery Planning**: Establish recovery procedures before they're needed
-5. **Spending Limits**: Configure appropriate transaction limits
-
-## 🛣 Roadmap
-
-### Phase 1: Security Foundation (Q3 2024)
-
-- [ ] Complete permission validation system
-- [ ] Implement all authentication methods
-- [ ] Add comprehensive error handling
-- [ ] Security audit and penetration testing
-
-### Phase 2: Advanced Features (Q4 2024)
-
-- [ ] Multi-signature support
-- [ ] Social recovery mechanisms
-- [ ] Session key management
-- [ ] Cross-chain integration
-
-### Phase 3: Ecosystem Integration (Q1 2025)
-
-- [ ] Wallet integration (Phantom, Solflare)
-- [ ] DApp SDK and tooling
-- [ ] Gas sponsorship/paymaster
-- [ ] Advanced delegation patterns
-
-### Phase 4: Enterprise Features (Q2 2025)
-
-- [ ] Enterprise SSO integration
-- [ ] Compliance and auditing tools
-- [ ] Advanced recovery workflows
-- [ ] Custom authentication plugins
-
-## 🤝 Contributing
-
-We welcome contributions! Please see our [Contributing Guide](CONTRIBUTING.md) for details.
-
-### Development Priorities
-
-1. **Security First**: All contributions must prioritize security
-2. **Test Coverage**: New features require comprehensive tests
-3. **Documentation**: Code must be well-documented
-4. **Compatibility**: Maintain backwards compatibility where possible
-
-### Reporting Security Issues
-
-Please report security vulnerabilities to security@yourorg.com. Do not create public issues for security problems.
-
-## 📚 Documentation
-
-- [Architecture Overview](docs/architecture.md)
-- [Authentication Guide](docs/authentication.md)
-- [Permission System](docs/permissions.md)
-- [Security Analysis](security.md)
-- [API Reference](docs/api.md)
-
-## 📄 License
-
-This project is licensed under the MIT License - see the [LICENSE](LICENSE) file for details.
-
-## 🙏 Acknowledgments
-
-- Solana Foundation for the excellent development environment
-- EIP-4337 authors for account abstraction inspiration
-- Anchor Framework team for the development tools
-- Security researchers who contributed to the analysis
-
----
-
-**⚠️ Disclaimer**: This software is experimental and not ready for production use. Use at your own risk and always conduct thorough security audits before deploying to mainnet.
+The Ethereum test keys are the standard Hardhat/Anvil development accounts.


### PR DESCRIPTION
The previous README was largely aspirational: it documented a permission matrix, recovery system, and roadmap that don't exist in the code, and linked to docs files, a CONTRIBUTING guide, and an MIT license that aren't in the repo. This rewrite grounds the README in the actual implementation.

- Documents the real architecture: precompile + instruction-sysvar introspection, `AccountManager`/`AbstractAccount` PDAs, and the `execute_ek256` flow
- Honest per-method status: Ethereum (verify + execute), WebAuthn (verification only), OIDC/RSA (localnet PoC, tracked in #13)
- Flags the unauthenticated dev-helper instructions and other known gaps sourced from in-code TODOs
- Adds repo layout, toolchain requirements, and a test-spec reference